### PR TITLE
Don't use JS `eval`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Revision history for jsaddle-wasm
 
+## 0.1.2.0 -- 2025-06-27
+
+ * Internally, stop using JS `eval`. This allows usage with a `Content-Security-Policy` without `unsafe-eval` (but still with `wasm-unsafe-eval`).
+
+   For the same reason, expose `eval` and `evalFile` from `Language.Javascript.JSaddle.Wasm.TH` which allow to generate corresponding Wasm JSFFI imports for statically known strings.
+
+   Useful as a replacement of JSaddle's `eval` in downstream libraries
+
 ## 0.1.1.0 -- 2025-05-01
 
  * Bug fix: make GHCJS helpers globally available.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ An advantage of this approach is that computationally expensive operations in Wa
    runJSaddle(worker);
    ```
 
+Additionally, when other packages use the `Language.Javascript.JSaddle.Wasm.TH` module, you need to disable the `eval-via-jsffi` flag, e.g. by adding the following to your `cabal.project`:
+```cabal
+package jsaddle-wasm
+  flags: -eval-via-jsffi
+```
+
 ## Potential future work
 
  - Testing (e.g. via Selenium).

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
       },
       "locked": {
         "host": "gitlab.haskell.org",
-        "lastModified": 1747237596,
-        "narHash": "sha256-EyzTbLYHKXhEYGcIgYcYHevMjNOlizUL7lDQyv73eN8=",
+        "lastModified": 1749674157,
+        "narHash": "sha256-A+wyUfg/P3B7CW9ZH3JyaPMFdPTpXa2Q6CdffF2gl1s=",
         "owner": "haskell-wasm",
         "repo": "ghc-wasm-meta",
-        "rev": "fe5573f28327d12a1c47ec61d6bbe0cc9d7983dd",
+        "rev": "913a51e58b330f00e3b0ad5b89184cad328ea109",
         "type": "gitlab"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {

--- a/jsaddle-wasm.cabal
+++ b/jsaddle-wasm.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: jsaddle-wasm
-version: 0.1.1.0
+version: 0.1.2.0
 synopsis: Run JSaddle JSM with the GHC Wasm backend
 description: Run JSaddle @JSM@ with the GHC Wasm backend.
 category: Web, Javascript

--- a/jsaddle-wasm.cabal
+++ b/jsaddle-wasm.cabal
@@ -17,6 +17,14 @@ source-repository head
   location: https://github.com/amesgen/jsaddle-wasm
   type: git
 
+flag eval-via-jsffi
+  description:
+    Generate Wasm JSFFI imports for the TemplateHaskell utilities in
+    @Language.Javascript.JSaddle.Wasm.TH@.
+
+  default: True
+  manual: True
+
 common common
   ghc-options:
     -Wall
@@ -26,7 +34,9 @@ common common
   default-language: GHC2021
   default-extensions:
     BlockArguments
+    LambdaCase
     OverloadedStrings
+    TemplateHaskellQuotes
 
 library js
   import: common
@@ -45,6 +55,7 @@ library
   hs-source-dirs: src
   exposed-modules:
     Language.Javascript.JSaddle.Wasm
+    Language.Javascript.JSaddle.Wasm.TH
 
   other-modules:
     Language.Javascript.JSaddle.Wasm.Internal
@@ -53,14 +64,22 @@ library
     base >=4.16 && <5,
     jsaddle ^>=0.9,
     jsaddle-wasm:js,
+    template-haskell >=2.20 && <2.24,
 
   if arch(wasm32)
     build-depends:
       aeson >=2 && <2.3,
       bytestring >=0.11 && <0.13,
       ghc-experimental ^>=0.1 || >=9.1000 && <9.1300,
+      parser-regex ^>=0.3,
       stm ^>=2.5,
 
+    other-modules:
+      Language.Javascript.JSaddle.Wasm.Internal.TH
+
     hs-source-dirs: src-wasm
+
+    if flag(eval-via-jsffi)
+      cpp-options: -DEVAL_VIA_JSFFI
   else
     hs-source-dirs: src-native

--- a/src-wasm/Language/Javascript/JSaddle/Wasm/Internal/TH.hs
+++ b/src-wasm/Language/Javascript/JSaddle/Wasm/Internal/TH.hs
@@ -1,0 +1,63 @@
+module Language.Javascript.JSaddle.Wasm.Internal.TH
+  ( eval,
+    patchedGhcjsHelpers,
+  )
+where
+
+import Control.Applicative (asum, many)
+import Data.ByteString.Lazy.Char8 qualified as BLC8
+import Language.Haskell.TH qualified as TH
+import Language.Haskell.TH.Syntax qualified as TH
+import Language.Javascript.JSaddle.Run.Files qualified as JSaddle.Files
+import Regex.List qualified as Re
+
+eval :: String -> [TH.Q TH.Type] -> TH.Q TH.Exp
+eval jsChunk argTys = do
+  ffiImportName <- TH.newName . show =<< TH.newName "wasm_ffi_import_eval"
+  sig <- mkSig argTys
+  let ffiImport =
+        TH.ForeignD $
+          TH.ImportF
+            TH.JavaScript
+            TH.Safe
+            jsChunk
+            ffiImportName
+            sig
+  TH.addTopDecls [ffiImport]
+  TH.varE ffiImportName
+  where
+    mkSig = \case
+      [] -> [t|IO ()|]
+      t : ts -> [t|$t -> $(mkSig ts)|]
+
+-- | The JSaddle GHCJS helpers need to be available in the global scope.
+-- Usually, this is done by evaluating them in a global scope; however, we want
+-- to avoid JS eval (due to CSP, see
+-- https://github.com/tweag/ghc-wasm-miso-examples/issues/33), so we instead use
+-- a hack, namely transforming
+--
+-- > function foo(a) {
+-- >   return a + 1;
+-- > }
+--
+-- into
+--
+-- > globalThis["foo"] = function(a) {
+-- >   return a + 1;
+-- > }
+--
+-- Of course, this only works because of the very particular structure of
+-- 'ghcjsHelpers'; but it changes very rarely (didn't change non-trivially in
+-- the last 10 years), so this seems acceptable.
+patchedGhcjsHelpers :: String
+patchedGhcjsHelpers =
+  Re.replaceAll re $ BLC8.unpack JSaddle.Files.ghcjsHelpers
+  where
+    re :: Re.RE Char String
+    re =
+      asum
+        [ f <$> (Re.list "function " *> many (Re.satisfy (/= '('))),
+          "\n};" <$ Re.list "\n}"
+        ]
+      where
+        f name = "globalThis[" <> show name <> "] = function"

--- a/src/Language/Javascript/JSaddle/Wasm/TH.hs
+++ b/src/Language/Javascript/JSaddle/Wasm/TH.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE CPP #-}
+
+-- | Utilities for evaluating (at runtime) JS code that is known at compile time
+-- via TemplateHaskell /without/ relying on JS @eval@.
+--
+-- For niche use cases, generating JSaddle-based 'JSaddle.eval' instead is
+-- possible by disabling the @eval-via-jsffi@ Cabal flag.
+--
+-- For convenience, on non-Wasm GHCs, the semantics of having @eval-via-jsffi@
+-- disabled are used.
+module Language.Javascript.JSaddle.Wasm.TH where
+
+import Language.Haskell.TH qualified as TH
+import Language.Javascript.JSaddle qualified as JSaddle
+#ifdef EVAL_VIA_JSFFI
+import Control.Monad.IO.Class (liftIO)
+import Language.Javascript.JSaddle.Wasm.Internal.TH qualified as Internal
+#else
+import Data.Functor (void)
+#endif
+
+-- | Generate an expression that, when called, evaluates the given chunk of JS
+-- code. Additionally, a list of argument types can be specified.
+--
+-- For example,
+--
+-- > $(eval "console.log('hi')") :: JSM ()
+--
+-- will print \"hi\" to the console when executed.
+--
+-- Internally, this generates the following code:
+--
+--  * If the Cabal flag @eval-via-jsffi@ is enabled (the default): An
+--    appropriate safe Wasm JSFFI import.
+--
+--  * If @eval-via-jsffi@ is disabled: Use JSaddle's 'JSaddle.eval'.
+eval :: String -> TH.Q TH.Exp
+#if EVAL_VIA_JSFFI
+eval chunk = [|liftIO $(Internal.eval chunk []) :: JSaddle.JSM ()|]
+#else
+eval chunk = [|void $ JSaddle.eval chunk|]
+#endif
+
+-- | Like 'eval', but read the JS code to evaluate from a file.
+evalFile :: FilePath -> TH.Q TH.Exp
+evalFile path = do
+  chunk <- TH.runIO $ readFile path
+  eval chunk


### PR DESCRIPTION
By generating an appropriate Wasm JSFFI import via TemplateHaskell

See https://github.com/tweag/ghc-wasm-miso-examples/issues/33

Maybe extract a standalone `inline-wasm` library?