### PR TITLE
Always `evaluate` safe FFI calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Revision history for jsaddle-wasm
 
+## 0.1.2.1 -- 2025-07-10
+
+ * Internally, stop using JS `eval`. This allows usage with a `Content-Security-Policy` without `unsafe-eval` (but still with `wasm-unsafe-eval`).
+
+   For the same reason, expose `eval` and `evalFile` from `Language.Javascript.JSaddle.Wasm.TH` which allow to generate corresponding Wasm JSFFI imports for statically known strings.
+
+   Useful as a replacement of JSaddle's `eval` in downstream libraries
+
 ## 0.1.2.0 -- 2025-06-27
 
  * Internally, stop using JS `eval`. This allows usage with a `Content-Security-Policy` without `unsafe-eval` (but still with `wasm-unsafe-eval`).

--- a/jsaddle-wasm.cabal
+++ b/jsaddle-wasm.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: jsaddle-wasm
-version: 0.1.2.0
+version: 0.1.2.1
 synopsis: Run JSaddle JSM with the GHC Wasm backend
 description: Run JSaddle @JSM@ with the GHC Wasm backend.
 category: Web, Javascript

--- a/jsaddle-wasm.cabal
+++ b/jsaddle-wasm.cabal
@@ -28,6 +28,7 @@ flag eval-via-jsffi
 common common
   ghc-options:
     -Wall
+    -Wimplicit-lift
     -Wunused-packages
     -Wredundant-constraints
 

--- a/src-wasm/Language/Javascript/JSaddle/Wasm/Internal.hs
+++ b/src-wasm/Language/Javascript/JSaddle/Wasm/Internal.hs
@@ -58,11 +58,10 @@ run entryPoint = do
                            ]
                    JSaddle.Wasm.TH.eval (BLC8.unpack s) (replicate 3 [t|JSVal|])
                )
-        evaluate
-          =<< eval
-            processResultCallback
-            processResultSyncCallback
-            readBatchCallback
+        eval
+          processResultCallback
+          processResultSyncCallback
+          readBatchCallback
 
   $(JSaddle.Wasm.TH.eval JSaddle.Wasm.TH.patchedGhcjsHelpers [])
 


### PR DESCRIPTION
Just to avoid potential surprises; I haven't seen the lack of this causing problems anywhere so far, but better be on the safe side.